### PR TITLE
[1.7.0] 버전 업데이트

### DIFF
--- a/README-US.md
+++ b/README-US.md
@@ -88,11 +88,12 @@ getAvatarUrlfromGithub(USER_NAME)
 
 // with asyncWave
 asyncWave<GithubUser>([USER_NAME, getAvatarUrlfromGithub], {
-  onBefore: () => {
-    startLoadingIndicator();
+  onBefore: async () => {
+    await setFetchLog() // Errors inside the handler are also caught! [1]
+    startLoadingIndicator(); 
   },
   onSuccess: async (githubUser) => {
-    await showAvatar(githubUser); // 핸들러 내부 에러도 캐치됩니다!
+    await showAvatar(githubUser); // Errors inside the handler are also caught! [2]
     console.log(`avatar_url: ${githubUser.avatar_url}`);
   },
   onError: (error) => {

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ async function getAvatarUrlfromGithub(userName: string): Promise<GithubUser> {
 }
 
 // Promises chaining
+await setFetchLog();
 startLoadingIndicator();
 getAvatarUrlfromGithub(USER_NAME)
   .then(showAvatar)
@@ -88,11 +89,12 @@ getAvatarUrlfromGithub(USER_NAME)
 
 // with asyncWave
 asyncWave<GithubUser>([USER_NAME, getAvatarUrlfromGithub], {
-  onBefore: () => {
-    startLoadingIndicator();
+  onBefore: async () => {
+    await setFetchLog() // 핸들러 내부 에러도 캐치됩니다! [1]
+    startLoadingIndicator(); 
   },
   onSuccess: async (githubUser) => {
-    await showAvatar(githubUser); // 핸들러 내부 에러도 캐치됩니다!
+    await showAvatar(githubUser); // 핸들러 내부 에러도 캐치됩니다! [2]
     console.log(`avatar_url: ${githubUser.avatar_url}`);
   },
   onError: (error) => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "async-wave",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "A sequential method chain for asynchronous execution of callback functions, safely converting and passing any value as a promise.",
   "type": "commonjs",
   "main": "dist/index.js",

--- a/src/__tests__/asyncwave.spec.ts
+++ b/src/__tests__/asyncwave.spec.ts
@@ -165,9 +165,9 @@ describe('asyncWave()', () => {
     describe('beforeStart', () => {
       const mockBeforeStart = jest.fn();
 
-      test('메서드 체이닝이 실행되기 전에 가장 먼저 실행되어야 한다.', () => {
-        asyncWave<number, number>(10, [fn1, fn2], {
-          onBefore: () => {
+      test('메서드 체이닝이 실행되기 전에 가장 먼저 실행되어야 한다.', async () => {
+        await asyncWave<number, number>(10, [fn1, fn2], {
+          onBefore: async () => {
             mockBeforeStart();
           },
           onSuccess: (received) => {
@@ -186,15 +186,31 @@ describe('asyncWave()', () => {
         ).rejects.toThrowError('new Error');
       });
 
-      test('에러 핸들러를 전달하면 외부로 방출되지 않고 캐치되어야 한다.', () => {
+      test('에러 핸들러를 전달하면 외부로 방출되지 않고 캐치되어야 한다.', async () => {
         const onErrorMockFn = jest.fn();
 
-        asyncWave<number, number>(10, [fn1], {
+        await asyncWave<number, number>(10, [fn1], {
           onBefore: () => throwError(),
           onError: () => onErrorMockFn(),
         });
 
         expect(onErrorMockFn).toHaveBeenCalled();
+      });
+
+      test('에러가 발생하면 핸들러가 실행되지 말아야 한다.', async () => {
+        const onHandlerMockFn = jest.fn();
+        const onSuccessMockFn = jest.fn();
+        const onErrorMockFn = jest.fn();
+
+        await asyncWave<number, number>(10, [onHandlerMockFn, fn1], {
+          onBefore: () => throwError(),
+          onError: () => onErrorMockFn(),
+          onSuccess: () => onSuccessMockFn(),
+        });
+
+        expect(onErrorMockFn).toHaveBeenCalled();
+        expect(onHandlerMockFn).not.toHaveBeenCalled();
+        expect(onSuccessMockFn).not.toHaveBeenCalled();
       });
     });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,7 @@
 import clonedeep from 'lodash.clonedeep';
 
 import type { CallbackFns, Options, StartValue } from './utils/types';
-import {
-  createOn,
-  createPromiseRecursiveFn,
-  guard,
-  promisify,
-} from './utils/fn';
+import { createOn, createPromiseRecursiveFn, promisify } from './utils/fn';
 
 /**
  * @see https://github.com/jeongbaebang/async-wave
@@ -81,10 +76,11 @@ async function asyncWave<SV, R>(
   const onSuccess = createOn.success(options?.onSuccess);
   const onSettled = createOn.settled(options?.onSettled);
   const onBeforeStart = createOn.before(options?.onBefore);
+  const startPromiseRecursiveFn = () => promiseRecursiveFn(firstPromiseFn());
 
-  guard(onBeforeStart, onError);
-
-  return promiseRecursiveFn(firstPromiseFn())
+  return Promise.resolve()
+    .then(onBeforeStart)
+    .then(startPromiseRecursiveFn)
     .then(onSuccess)
     .catch(onError)
     .finally(onSettled) as Promise<R>;

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -6,7 +6,19 @@ import { payload } from './db';
 const DEFUALT_URL = 'http://localhost';
 
 export const handlers = [
-  rest.get<Response>(`${DEFUALT_URL}/api/v1/users`, (_req, res, ctx) => {
+  rest.get<Response>(`${DEFUALT_URL}/api/v1/users`, (req, res, ctx) => {
+    const isError = req.url.searchParams.get('isError');
+
+    if (isError) {
+      return res(
+        ctx.status(403),
+        // And a response body, if necessary
+        ctx.json({
+          errorMessage: `User not found`,
+        }),
+      );
+    }
+
     return res(
       ctx.status(200),
       ctx.json({

--- a/src/utils/fn.ts
+++ b/src/utils/fn.ts
@@ -40,9 +40,13 @@ export const createOn = {
     };
   },
   before(onBefore?: OnBefore) {
-    return () => {
+    return async () => {
       if (onBefore) {
-        onBefore();
+        try {
+          await onBefore();
+        } catch (error) {
+          return Promise.reject(error); // 에러가 상위 프로미스 체인에 제대로 전파하도록 처리
+        }
       }
     };
   },
@@ -102,23 +106,24 @@ export function createPromiseRecursiveFn<R>(callbackFns: CallbackFns) {
   };
 }
 
-export function guard<T extends any[], R>(
-  f: (...args: T) => R,
-  ef: (error: unknown) => void,
-  args: T,
-): R | void;
+// export function guard<T extends any[], R>(
+//   f: (...args: T) => R,
+//   ef: (error: unknown) => void,
+//   args: T,
+// ): R | Error;
 
-// args를 받지 않는 경우
-export function guard<R>(f: () => R, ef: (error: unknown) => void): R | void;
+// // args를 받지 않는 경우
+// export function guard<R>(f: () => R, ef: (error: unknown) => void): R | Error;
 
-export function guard<T extends any[], R>(
-  f: (...args: T | []) => R,
-  ef: (error: unknown) => void,
-  args?: T,
-): R | void {
-  try {
-    return args ? f(...args) : f();
-  } catch (error) {
-    ef(error);
-  }
-}
+// export function guard<T extends any[], R>(
+//   f: (...args: T | []) => R,
+//   ef: (error: unknown) => void,
+//   args?: T,
+// ) {
+//   try {
+//     return args ? f(...args) : f();
+//   } catch (error) {
+//     ef(error);
+//     return new Error();
+//   }
+// }

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -4,7 +4,7 @@ export type OnSuccess<T> = (received: T) => void;
 
 export type OnSettled = () => void;
 
-export type OnBefore = () => void;
+export type OnBefore = () => Promise<void>;
 
 export interface Option<T> {
   onError: OnError;


### PR DESCRIPTION
### [1.7.0] 기록 로그
onBefore 핸들러 동기 -> 비동기 구현 변경

**코멘트**
onBefore 핸들러에서 발생하는 에러를 동일한 프로미스 체인으로 전파하게 구현을 변경했습니다. 이로 인해, 메서드 체이닝이나 onSuccess 함수 대신에 onError 핸들러가 직접 실행되거나, 에러가 외부로 전달됩니다.